### PR TITLE
feat/resize-image-of-editor : 에디터 이미지에 resize 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "mongoose": "^8.0.0",
     "next": "13.5.4",
     "next-auth": "^4.24.5",
+    "quill-image-resize": "^3.0.9",
+    "quill-image-resize-module-ts": "^3.0.3",
     "react": "^18",
     "react-dom": "^18",
     "react-html-parser": "^2.0.2",

--- a/src/components/ArticleForm/Editor/_shared/utils.ts
+++ b/src/components/ArticleForm/Editor/_shared/utils.ts
@@ -30,7 +30,6 @@ const imageHandler = (quillRef: MutableRefObject<ReactQuill | undefined>) => {
         /**
          * Firebase Method : uploadBytes, getDownloadURL
          */
-
         const snapShot = await uploadBytes(storageRef, file)
         const url = await getDownloadURL(snapShot.ref)
 

--- a/src/components/ArticleForm/Editor/_shared/utils.ts
+++ b/src/components/ArticleForm/Editor/_shared/utils.ts
@@ -1,10 +1,11 @@
+import { MutableRefObject } from 'react'
 import { ImageResize } from 'quill-image-resize-module-ts'
 import ReactQuill, { Quill } from 'react-quill'
-import { storage } from '@/Firebase'
+// eslint-disable-next-line import/order
 import { uploadBytes, getDownloadURL, ref } from 'firebase/storage'
-
+import { storage } from '@/Firebase'
 import { TOOL_BARS } from './constants'
-import { MutableRefObject } from 'react'
+
 Quill.register('modules/ImageResize', ImageResize)
 
 const imageHandler = (quillRef: MutableRefObject<ReactQuill | undefined>) => {

--- a/src/components/ArticleForm/Editor/_shared/utils.ts
+++ b/src/components/ArticleForm/Editor/_shared/utils.ts
@@ -1,14 +1,61 @@
 import { ImageResize } from 'quill-image-resize-module-ts'
-import { Quill } from 'react-quill'
+import ReactQuill, { Quill } from 'react-quill'
+import { storage } from '@/Firebase'
+import { uploadBytes, getDownloadURL, ref } from 'firebase/storage'
 
 import { TOOL_BARS } from './constants'
+import { MutableRefObject } from 'react'
 Quill.register('modules/ImageResize', ImageResize)
 
-export const convertModules = (imageHandler: () => void) => ({
+const imageHandler = (quillRef: MutableRefObject<ReactQuill | undefined>) => {
+  const input = document.createElement('input')
+
+  input.setAttribute('type', 'file')
+  input.setAttribute('accept', 'image/*')
+  input.click()
+  input.addEventListener('change', () => {
+    ;(async () => {
+      if (!quillRef?.current || input.files === null) return
+
+      const editor = quillRef.current.getEditor()
+      const file = input.files[0]
+      const range = editor.getSelection(true)
+
+      try {
+        /**
+         * 파일명을 "image/Date.now()"로 저장
+         */
+        const storageRef = ref(storage, `image/${Date.now()}`)
+
+        /**
+         * Firebase Method : uploadBytes, getDownloadURL
+         */
+
+        const snapShot = await uploadBytes(storageRef, file)
+        const url = await getDownloadURL(snapShot.ref)
+
+        /**
+         * 이미지 URL 에디터에 삽입
+         */
+        editor.insertEmbed(range.index, 'image', url)
+        /**
+         * URL 삽입 후 커서를 이미지 뒷 칸으로 이동
+         */
+        editor.setSelection(range.index + 1, 0)
+      } catch (error) {
+        console.log(error)
+      }
+    })()
+  })
+}
+
+export const convertModules = (
+  quillRef: MutableRefObject<ReactQuill | undefined>,
+) => ({
   toolbar: {
     container: TOOL_BARS,
     handlers: {
-      image: imageHandler,
+      image: () => imageHandler(quillRef),
     },
   },
   ImageResize: {

--- a/src/components/ArticleForm/Editor/_shared/utils.ts
+++ b/src/components/ArticleForm/Editor/_shared/utils.ts
@@ -1,4 +1,9 @@
+import { ImageResize } from 'quill-image-resize-module-ts'
+import { Quill } from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
+
 import { TOOL_BARS } from './constants'
+Quill.register('modules/ImageResize', ImageResize)
 
 export const convertModules = (imageHandler: () => void) => ({
   toolbar: {
@@ -6,5 +11,9 @@ export const convertModules = (imageHandler: () => void) => ({
     handlers: {
       image: imageHandler,
     },
+  },
+  ImageResize: {
+    parchment: Quill.import('parchment'),
+    modules: ['Resize', 'DisplaySize', 'Toolbar'],
   },
 })

--- a/src/components/ArticleForm/Editor/_shared/utils.ts
+++ b/src/components/ArticleForm/Editor/_shared/utils.ts
@@ -1,6 +1,5 @@
 import { ImageResize } from 'quill-image-resize-module-ts'
 import { Quill } from 'react-quill'
-import 'react-quill/dist/quill.snow.css'
 
 import { TOOL_BARS } from './constants'
 Quill.register('modules/ImageResize', ImageResize)
@@ -14,6 +13,6 @@ export const convertModules = (imageHandler: () => void) => ({
   },
   ImageResize: {
     parchment: Quill.import('parchment'),
-    modules: ['Resize', 'DisplaySize', 'Toolbar'],
+    modules: ['Resize', 'DisplaySize'],
   },
 })

--- a/src/components/ArticleForm/Editor/index.tsx
+++ b/src/components/ArticleForm/Editor/index.tsx
@@ -3,10 +3,8 @@
 import { useMemo, useRef } from 'react'
 import ReactQuill from 'react-quill'
 import 'react-quill/dist/quill.snow.css'
-import { uploadBytes, getDownloadURL, ref } from 'firebase/storage'
 
 import { ArticleInterface } from '@/apis/articles'
-import { storage } from '@/Firebase'
 
 import { FORMATS, convertModules } from './_shared'
 
@@ -18,48 +16,7 @@ interface Props {
 const Editor = ({ contentHtml, onChangeContent }: Props) => {
   const quillRef = useRef<ReactQuill>()
 
-  const imageHandler = () => {
-    const input = document.createElement('input')
-    input.setAttribute('type', 'file')
-    input.setAttribute('accept', 'image/*')
-    input.click()
-    input.addEventListener('change', () => {
-      ;(async () => {
-        if (!quillRef?.current || input.files === null) return
-
-        const editor = quillRef.current.getEditor()
-        const file = input.files[0]
-        const range = editor.getSelection(true)
-
-        try {
-          /**
-           * 파일명을 "image/Date.now()"로 저장
-           */
-          const storageRef = ref(storage, `image/${Date.now()}`)
-
-          /**
-           * Firebase Method : uploadBytes, getDownloadURL
-           */
-
-          const snapShot = await uploadBytes(storageRef, file)
-          const url = await getDownloadURL(snapShot.ref)
-
-          /**
-           * 이미지 URL 에디터에 삽입
-           */
-          editor.insertEmbed(range.index, 'image', url)
-          /**
-           * URL 삽입 후 커서를 이미지 뒷 칸으로 이동
-           */
-          editor.setSelection(range.index + 1, 0)
-        } catch (error) {
-          console.log(error)
-        }
-      })()
-    })
-  }
-
-  const modules = useMemo(() => convertModules(imageHandler), [])
+  const modules = useMemo(() => convertModules(quillRef), [])
 
   return (
     <ReactQuill

--- a/yarn.lock
+++ b/yarn.lock
@@ -7385,7 +7385,24 @@ quill-delta@^3.6.2:
     extend "^3.0.2"
     fast-diff "1.1.2"
 
-quill@^1.3.7:
+quill-image-resize-module-ts@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/quill-image-resize-module-ts/-/quill-image-resize-module-ts-3.0.3.tgz#47e6d81214719b7a745c2d4e53cad2cef09ad4dc"
+  integrity sha512-NMWw67zCfGxE0AyPTVLWMTAs71eKerd+jJJqu9ZuPBGZl7vc+Jtb+tmfx33pC3h0deVYqgOMXYzbFBIRmu/WuQ==
+  dependencies:
+    lodash "^4.17.4"
+    quill "^1.3.4"
+
+quill-image-resize@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/quill-image-resize/-/quill-image-resize-3.0.9.tgz#5677fb6257560bff951153ddbdb836758e49f804"
+  integrity sha512-5Dk0nixhbFsCwSWtPU9qqqtfM2gURfaP+pbBhQvAoMJoF4p99xbAibfAI3gsZJkbWUodoK2iAPf1V5oTSpv9ww==
+  dependencies:
+    lodash "^4.17.4"
+    quill "^1.2.2"
+    raw-loader "^0.5.1"
+
+quill@^1.2.2, quill@^1.3.4, quill@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
   integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
@@ -7421,6 +7438,11 @@ raw-body@2.5.2, raw-body@^2.3.3:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+raw-loader@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
+  integrity sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q==
 
 rc@^1.2.8:
   version "1.2.8"


### PR DESCRIPTION
# What is this PR?

에디터 이미지에 resize 기능 추가

# Changes

- resize 기능 추가
- 리팩토링 : imageHandler를 utils 파일로 이동

# Screenshot

| action | image                      |
| ------ | -------------------------- |
| 사진 클릭 시, resize 가능    | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/c1f90251-e314-42b8-b485-569a9acc2ba9' height='200'/> |

# Questions

더 잘 짤 방법이 있을까?

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다.

<details>
        <summary>익명 함수로 wrapping해서 원할 때, 함수 호출하기</summary>

어려웠던 부분은 아래의 코드였다.

```jsx
// 제작하는 함수
export const convertModules = (
  quillRef: MutableRefObject<ReactQuill | undefined>,
) => ({
  toolbar: {
    ...생략
    handlers: {
      image: imageHandler(quillRef), // 1안
      image: () => imageHandler(quillRef), // 2안
    },
  },
  ...생략
})
```

```jsx
// 사용처
const modules = useMemo(() => convertModules(quillRef), [])
```

1안으로 하면 화면을 딱 띄우자 마자 imageHandler가 2번 실행 되는 것 같고 

2안으로 하면 이미지 아이콘을 실행할 때마다 imageHandler가 실행되었다.

제가 원하는대로 동작하는 것은 2안인데, 왜 서로 다르게 동작하는지 이해를 하지 못했었다.

아직 확실하지는 않으나 주변 개발자에게도 물어보고 chatGPT한테도 물어본 결과, convertModules함수의 handlers.image()는 렌더링과 함께 즉시 실행이 되며 (2번 되는데 이 또한 strict mode를 원인으로 보고 있다.) 2안의 경우 익명함수로 한 번 감쌌지만 1안의 경우에는 함수가 바로 실행이 되어서 그 결괏값을 보여주게 된다고 판단했다.

조금 헤맸던 부분인데 익명함수에 대해서도 리마인드 하고 strict mode도 아주 오래전 봤던 것 같은데 리마인드 할 수 있는 시간이였다.
</details>
