### PR TITLE
fix : add logic that search in title & content

### DIFF
--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -29,8 +29,13 @@ export interface GetArticleResponseInterface {
   article: GetArticleInterface
 }
 
+export interface ArticleOfGetArticlesResponseInterface
+  extends Omit<GetArticleInterface, 'content'> {
+  content: Pick<ArticleContentInterface, '_id'>
+}
+
 export interface GetArticlesResponseInterface {
-  articles: GetArticleInterface[]
+  articles: ArticleOfGetArticlesResponseInterface[]
 }
 
 export const createArticle = async (article: ArticleInterface) => {

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -56,11 +56,11 @@ export const GET = async (request: NextRequest) => {
         },
         {
           $project: {
+            _id: 1,
             title: 1,
             content: { _id: 1 },
             createdAt: 1,
             updatedAt: 1,
-            __v: 1,
           },
         },
       ])

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -36,7 +36,34 @@ export const GET = async (request: NextRequest) => {
   }
 
   const articles = searchTerm
-    ? await Article.find(searchCondition).populate('content')
+    ? await Article.aggregate([
+        {
+          $lookup: {
+            from: 'articlecontents',
+            localField: 'content',
+            foreignField: '_id',
+            as: 'content',
+          },
+        },
+        {
+          $unwind: {
+            path: '$content',
+            preserveNullAndEmptyArrays: true,
+          },
+        },
+        {
+          $match: searchCondition,
+        },
+        {
+          $project: {
+            title: 1,
+            content: { _id: 1 },
+            createdAt: 1,
+            updatedAt: 1,
+            __v: 1,
+          },
+        },
+      ])
     : await Article.find()
 
   return NextResponse.json({ articles })

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 
-import { GetArticleInterface } from '@/apis/articles'
+import { ArticleOfGetArticlesResponseInterface } from '@/apis/articles'
 
 import Search from './Search'
 
 interface Props {
-  articles: GetArticleInterface[] | undefined
+  articles: ArticleOfGetArticlesResponseInterface[] | undefined
 }
 
 const Home = ({ articles }: Props) => {


### PR DESCRIPTION
# What is this PR?

article의 본문도 검색 가능하게 하기

# Changes

- article의 본문도 검색 가능하게 하기
    - 구체적인 구현 조건
        - article의 title(제목)과 content(본문)에서 검색을 하되, return 할 때는 조건에 부합하는 content의 _id까지만 나오도록 함. (본문 내용은 반환하지 않게끔 함.)
        - 본문 내용은 반환하지 않게끔 하는 이유
            
            검색 시에 보여지는 내용이 article의 개요 부분들이라 굳이 article 클릭 전에 content 데이터까지 들고 다닐 이유가 없다고 생각해서.

    <details>
        <summary>구현 방법</summary>

        ```tsx


        const searchCondition = {
            $or: [
              { title: { $regex: searchTerm, $options: 'i' } },
              { 'content.text': { $regex: searchTerm, $options: 'i' } },
            ],
        }
        
        const articles = searchTerm
            ? await Article.aggregate([
                {
                  $lookup: {
                    from: 'articlecontents',
                    localField: 'content',
                    foreignField: '_id',
                    as: 'content',
                  },
                },
                {
                  $unwind: {
                    path: '$content',
                    preserveNullAndEmptyArrays: true,
                  },
                },
                {
                  $match: searchCondition,
                },
                {
                  $project: {
                    _id: 1,
                    title: 1,
                    content: { _id: 1 },
                    createdAt: 1,
                    updatedAt: 1,
                  },
                },
              ])
            : await Article.find()

        ```

        - 해석
            
            주어진 코드는 MongoDB 집계(Aggregation) 프레임워크를 사용하여 검색 조건에 따라 `Article`과 `ArticleContent`를 조인하고, 해당 조건에 맞는 결과를 반환합니다.
            
            여기서 사용된 파이프라인은 다음과 같습니다.
            
            1. `$lookup`: `Article`의 `content` 필드를 사용하여 `ArticleContent`와 조인합니다.
            2. `$unwind`: `content` 배열을 풀어줍니다. 이것은 `content`가 배열로 들어갔을 때, 각 요소를 별도의 문서로 만들어줍니다.
            3. `$match`: 주어진 검색 조건에 따라 문서를 필터링합니다. 검색어로 제목(title) 또는 `content.text` 필드를 대소문자 구분 없이(옵션 'i') 검색합니다.
            4. `$project`: 결과 문서에 출력할 필드를 선택합니다. 여기서는 `_id`, `title`, `content`, `createdAt`, `updatedAt` 필드를 선택하고, `content` 필드의 경우 `_id` 필드만 선택합니다.
            
            이를 통해 검색어에 해당하는 `Article`과 `ArticleContent`를 찾아서 결과로 반환합니다.
    </details>       
        

- 여러 article을 조회하는 경우, article 본문의 id만 받아올 수 있다는 것으로 타입 수정 및 반영
    - 해당 타입 : `ArticleOfGetArticlesResponseInterface`
# Questions

더 잘 짤 수 있는 방법이 있을까

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다.
<details>
        <summary>chatGPT와 함께 백엔드 로직을 수정해보다. (article의 본문도 검색 가능하게 하기)</summary>

대부분 chatGPT만을 통해 검색을 했는데 그 이유는 mongoose를 아주 많이 이해하지 못한 상태이기 때문이다. (온전히 이해하긴 시간이 없었다.)

무수히 많은 검색을 해도 원하는 결과가 나오지를 않았다.
title만 또는 content만 검색이 되었다.
처음에는 내 백엔드 로직 (schema, interface 등)을 알려줬다. 그리고 내 요구 사항을 말했다.
답이 나오지 않자 까다로운 내 요청 사항이 문제라고 생각했다. (요청 사항 title과 content를 검색가능하게 하면서도 return 할 때는 content의 _id만 달라)
계속해서 던져주는 답은 대부분 title만 검색 되었다.
mongoose 문법을 제대로 알지 못했기 때문에 너무 답답하고 막막했다. 뭘 고쳐야할지 모르겠었다.
(참고로 중간에 mongoose 공식문서를 봤는데도 모르겠더라..)

그렇게 질문과 답이 도돌이표를 돌던 중에 질문을 바꾸어 보았다.
계속 title만 검색이 되었으니 이번에는 ‘content만 검색해서 일치되는 값을 반환하게 해줘’라는 질문을 던졌고 그러자 원하는 대로 이번엔 title이 아니라 content에서 원하는 값이 검색이 되었다.

```tsx
// chatGPT에서 알려준 값
export const GET = async (request: NextRequest) => {
  const searchTerm = request.nextUrl.searchParams.get('searchTerm')

  console.log('searchTerm', searchTerm)

  await connectMongoDB()

  const articles = await Article.aggregate([
    {
      $lookup: {
        from: 'articlecontents',
        localField: 'content',
        foreignField: '_id',
        as: 'content',
      },
    },
    {
      $unwind: {
        path: '$content',
        preserveNullAndEmptyArrays: true,
      },
    },
    {
      $match: {
        'content.text': { $regex: searchTerm, $options: 'i' },
				// 이 문법으로 content만 검색이 되었다.
      },
    },
    {
      $project: {
        title: 1,
        content: 1,
        createdAt: 1,
        updatedAt: 1,
        __v: 1,
      },
    },
  ])

  console.log('articles:', articles)

  return NextResponse.json({ articles })
}
```

그간 $match라는 문법을 통해 조건을 걸어주던 걸 알았던 나는 그간 title만 검색되게 하던 조건을 함께 넣어주어 봤다.

```tsx
// 수정해준 코드
const searchCondition = {
    $or: [
      { title: { $regex: searchTerm, $options: 'i' } },
      { 'content.text': { $regex: searchTerm, $options: 'i' } },
    ],
  }

...생략
    {
      $match: searchCondition
    },
...생략

```

그러자 원하는 대로 동작했다.

# 얻은 점 및 소감

얻은 점

- chatGPT를 통해 어렴풋이 파악한 문법들과 GPT에서 알려준 답안을 참고해서 원하는 결과를 얻을 수 있었던 것 같다.
- 또 답이 안나오면 그 반대편에 있는 질문을 하고 그 답안과 기존 답을 비교해보아서 정답에 가까운 힌트를 얻을 수 있었다.

소감

어제 몇 시간을 이 버그로 끙끙 앓았기 때문에 좀 뿌듯했다.
조금 아쉬운 점은 mongoose라는 문법을 제대로 아는 상태가 아니라 정확히는 이해하진 못한 상태다.
다행히 GPT한테 해결한 코드를 해석해달라고 해서 어떤 로직이 수행되고 있는지는 알고 있다.
시간 관계상 더 깊이 파는 건 어렵겠지만 플젝 하면서 조금씩이라도 알아두면 좋을 것 같다!
수고했다 내 자신 !!
</details>
