### PR TITLE
feat/add-useIsLogin-hook : useIsLogin 훅 추가하기

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,20 +1,28 @@
 'use client'
 
 import Link from 'next/link'
-import { signOut, useSession } from 'next-auth/react'
+import { signOut } from 'next-auth/react'
+import useIsLogin from '@/hooks/useIsLogin'
 
 const Navbar = () => {
-  const { data: session } = useSession()
+  const { isLoading, isLoggedin, session } = useIsLogin()
 
   return (
     <nav style={{ display: 'flex' }}>
       <Link href={'/'}>Home</Link>
-      <Link href={'/auth/login'}>Login</Link>
-      <div>
-        <Link href={'/article/write'}>Write</Link>
-        <div>{session?.user?.name}</div>
-        <button onClick={() => signOut()}>Log Out</button>
-      </div>
+      {!isLoading && (
+        <>
+          {isLoggedin ? (
+            <div>
+              <Link href={'/article/write'}>Write</Link>
+              <div>{session?.user?.name}</div>
+              <button onClick={() => signOut()}>Log Out</button>
+            </div>
+          ) : (
+            <Link href={'/auth/login'}>Login</Link>
+          )}
+        </>
+      )}
     </nav>
   )
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { signOut } from 'next-auth/react'
+
 import useIsLogin from '@/hooks/useIsLogin'
 
 const Navbar = () => {

--- a/src/containers/Article/Read/EditButtons/index.tsx
+++ b/src/containers/Article/Read/EditButtons/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
 import { deleteArticleById } from '@/apis/articles'
-import Link from 'next/link'
 import useIsLogin from '@/hooks/useIsLogin'
 
 const EditButtons = ({ id }: { id: string }) => {

--- a/src/containers/Article/Read/EditButtons/index.tsx
+++ b/src/containers/Article/Read/EditButtons/index.tsx
@@ -3,8 +3,11 @@
 import { useRouter } from 'next/navigation'
 
 import { deleteArticleById } from '@/apis/articles'
+import Link from 'next/link'
+import useIsLogin from '@/hooks/useIsLogin'
 
-const DeleteButton = ({ id }: { id: string }) => {
+const EditButtons = ({ id }: { id: string }) => {
+  const { isLoggedin } = useIsLogin()
   const router = useRouter()
 
   const handleClickDeleteButton = async () => {
@@ -26,6 +29,12 @@ const DeleteButton = ({ id }: { id: string }) => {
     }
   }
 
-  return <button onClick={handleClickDeleteButton}>DeleteButton</button>
+  if (!isLoggedin) return
+  return (
+    <>
+      <Link href={`edit/${id}`}>수정</Link>
+      <button onClick={handleClickDeleteButton}>삭제</button>
+    </>
+  )
 }
-export default DeleteButton
+export default EditButtons

--- a/src/containers/Article/Read/index.tsx
+++ b/src/containers/Article/Read/index.tsx
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs'
-import Link from 'next/link'
 
 import { GetArticleInterface } from '@/apis/articles'
 

--- a/src/containers/Article/Read/index.tsx
+++ b/src/containers/Article/Read/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 import { GetArticleInterface } from '@/apis/articles'
 
-import DeleteButton from './DeleteButton'
+import EditButtons from './EditButtons'
 import ArticleContent from '@/components/ArticleContent'
 import Comments from './Comments'
 
@@ -22,8 +22,7 @@ const Article = ({
   return (
     <div>
       <h2>제목: {title}</h2>
-      <Link href={`edit/${_id}`}>수정</Link>
-      <DeleteButton id={_id} />
+      <EditButtons id={_id} />
       <div>수정 일자: {dayjs(updatedAt).format('YYYY-MM-DD')}</div>
       <div>
         내용: <ArticleContent contentHtml={html} />

--- a/src/hooks/useIsLogin.ts
+++ b/src/hooks/useIsLogin.ts
@@ -1,0 +1,20 @@
+import { Session } from 'next-auth'
+import { useSession } from 'next-auth/react'
+
+interface ResultInterface {
+  isLoading: boolean
+  isLoggedin: boolean
+  session: Session | null
+}
+
+function useIsLogin(): ResultInterface {
+  const { data: session, status } = useSession()
+
+  return {
+    isLoading: status === 'loading',
+    isLoggedin: status === 'authenticated',
+    session,
+  }
+}
+
+export default useIsLogin


### PR DESCRIPTION
# What is this PR?

useIsLogin 커스텀 훅 추가 및 적용

# Changes

- isLogin 커스텀 훅
    - 추가
        - 위치 : `src/hooks/useIsLogin.ts`
        - 제작 이유 :
            
            보다 사용이 편리하고 가독성 좋게 하기 위해서
            
    - 적용
        - `Navbar` 컴포넌트
            
            로그인 여부에 따라 `로그인 버튼` vs `글 생성 / 유저 이름 / 로그아웃 버튼` 출현 결정됨
            
        - `EditButtons` 컴포넌트
            
            수정 / 삭제 버튼 출현 조건으로 활용
            
- 기타
    - 수정 / 삭제 버튼 위치를 `EditButtons` 로 통합시킴
        
        이유 : CSR을 사용해야 해서 (article이 server-component라, useIsLogin 커스텀 훅을 사용할 수 없는 상태였음)
        

# Screenshot

| action | image                      |
| ------ | -------------------------- |
| 1. 로그인 전 글 생성/수정/삭제 버튼, 유저명, 로그아웃 버튼이 출현하지 않음     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/31574af6-1a2c-454b-afa9-698a8a748a25' height='200'/> |
| 2. 로그인 후 모두 출현 및 동작 가능     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/699fc40d-2fa2-4f7b-9fc2-fb5010236403' height='200'/> |

# Questions

놓친 거나 더 잘 짤 수 있는 방법이 있을지

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다. 읽지 않으셔도 괜찮습니다.

<details>
        <summary>next-auth가 많은 걸 처리해줬다는 생각이 듦.</summary>
token, cookie 등 프론트에서 해줬던 기능들을 대다수 next-auth에서 처리해줘서 내가 할 것이 생각보다 많지 않았다. 

그래서 편리했지만 이 부분들에 대해 잘 알고 있는 것 같지 않아서 따로 공부를 좀 하는 것이 좋겠다는 생각이 들었다.

일단 프로젝트를 어느 정도 마친 후에 찾아 볼 수 있을 것 같다.
</details>
