### PR TITLE
refactor/organize-ArticleInterfaces : ArticleInterfaces 정리하기

### DIFF
--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -1,4 +1,5 @@
 import { API_URL_FOR_SSR, API_URL_FOR_CSR } from '@/constants/common'
+import { CategoryInterface } from '@/apis/categories'
 
 const API_ARTICLE_URL_FOR_SSR = `${API_URL_FOR_SSR}/api/articles`
 const API_ARTICLE_URL_FOR_CSR = `${API_URL_FOR_CSR}/api/articles`
@@ -9,11 +10,23 @@ export interface ArticleContentInterface {
   html: string
 }
 
-export interface ArticleInterface {
+export interface ArticleSimpleInterface {
   title: string
-  content: ArticleContentInterface
+  content: Pick<ArticleContentInterface, '_id'>
   category: string | null
 }
+
+export interface ArticleDetailInterface {
+  title: string
+  content: ArticleContentInterface
+  category: CategoryInterface | null
+}
+
+// export interface ArticleInterface {
+//   title: string
+//   content: ArticleContentInterface
+//   category: string | null
+// }
 
 export interface RevisedArticleInterface {
   newTitle: string
@@ -21,7 +34,19 @@ export interface RevisedArticleInterface {
   newCategory: string | null
 }
 
-export interface GetArticleInterface extends ArticleInterface {
+// export interface GetArticleInterface extends ArticleInterface {
+//   _id: string
+//   createdAt: string
+//   updatedAt: string
+// }
+
+export interface GetSimpleArticleInterface extends ArticleSimpleInterface {
+  _id: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface GetDetailArticleInterface extends ArticleDetailInterface {
   _id: string
   createdAt: string
   updatedAt: string
@@ -31,13 +56,8 @@ export interface GetArticleResponseInterface {
   article: GetArticleInterface
 }
 
-export interface ArticleOfGetArticlesResponseInterface
-  extends Omit<GetArticleInterface, 'content'> {
-  content: Pick<ArticleContentInterface, '_id'>
-}
-
 export interface GetArticlesResponseInterface {
-  articles: ArticleOfGetArticlesResponseInterface[]
+  articles: GetDetailArticleInterface[]
 }
 
 export const createArticle = async (article: ArticleInterface) => {

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -28,11 +28,11 @@ export interface ArticleDetailInterface {
 //   category: string | null
 // }
 
-export interface RevisedArticleInterface {
-  newTitle: string
-  newContent: ArticleContentInterface
-  newCategory: string | null
-}
+// export interface RevisedArticleInterface {
+//   newTitle: string
+//   newContent: ArticleContentInterface
+//   newCategory: string | null
+// }
 
 // export interface GetArticleInterface extends ArticleInterface {
 //   _id: string
@@ -57,7 +57,7 @@ export interface GetArticleResponseInterface {
 }
 
 export interface GetArticlesResponseInterface {
-  articles: GetDetailArticleInterface[]
+  articles: GetSimpleArticleInterface[]
 }
 
 // content : 디테일 / category : string
@@ -99,7 +99,7 @@ export const getArticles = async (searchTerm?: string) => {
 // content : 디테일 / category : string
 export const putArticleById = async (
   id: string,
-  revisedArticle: RevisedArticleInterface,
+  revisedArticle: ArticleDetailInterface,
 ) => {
   const res = await fetch(`${API_ARTICLE_URL_FOR_CSR}/${id}`, {
     method: 'PUT',

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -1,5 +1,5 @@
 import { API_URL_FOR_SSR, API_URL_FOR_CSR } from '@/constants/common'
-import { CategoryInterface } from '@/apis/categories'
+import type { CategoryInterface } from '@/apis/categories'
 
 const API_ARTICLE_URL_FOR_SSR = `${API_URL_FOR_SSR}/api/articles`
 const API_ARTICLE_URL_FOR_CSR = `${API_URL_FOR_CSR}/api/articles`

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -22,24 +22,6 @@ export interface ArticleDetailInterface {
   category: CategoryInterface | null
 }
 
-// export interface ArticleInterface {
-//   title: string
-//   content: ArticleContentInterface
-//   category: string | null
-// }
-
-// export interface RevisedArticleInterface {
-//   newTitle: string
-//   newContent: ArticleContentInterface
-//   newCategory: string | null
-// }
-
-// export interface GetArticleInterface extends ArticleInterface {
-//   _id: string
-//   createdAt: string
-//   updatedAt: string
-// }
-
 export interface GetSimpleArticleInterface extends ArticleSimpleInterface {
   _id: string
   createdAt: string
@@ -60,7 +42,6 @@ export interface GetArticlesResponseInterface {
   articles: GetSimpleArticleInterface[]
 }
 
-// content : 디테일 / category : string
 export const createArticle = async (article: ArticleDetailInterface) => {
   const res = await fetch(API_ARTICLE_URL_FOR_CSR, {
     method: 'POST',
@@ -73,7 +54,6 @@ export const createArticle = async (article: ArticleDetailInterface) => {
   return res
 }
 
-// content : 디테일 / category : 디테일
 export const getArticleById = async (id: string) => {
   const res = await fetch(`${API_ARTICLE_URL_FOR_SSR}/${id}`, {
     cache: 'no-store',
@@ -82,7 +62,6 @@ export const getArticleById = async (id: string) => {
   return res
 }
 
-// content : 심플 / category : 심플
 export const getArticles = async (searchTerm?: string) => {
   const res = await fetch(
     `${API_ARTICLE_URL_FOR_SSR}${
@@ -96,7 +75,6 @@ export const getArticles = async (searchTerm?: string) => {
   return res
 }
 
-// content : 디테일 / category : string
 export const putArticleById = async (
   id: string,
   revisedArticle: ArticleDetailInterface,
@@ -112,7 +90,6 @@ export const putArticleById = async (
   return res
 }
 
-// content : 심플 / category : 심플
 export const deleteArticleById = async (id: string) => {
   const res = await fetch(`${API_ARTICLE_URL_FOR_CSR}?id=${id}`, {
     method: 'DELETE',

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -53,14 +53,15 @@ export interface GetDetailArticleInterface extends ArticleDetailInterface {
 }
 
 export interface GetArticleResponseInterface {
-  article: GetArticleInterface
+  article: GetDetailArticleInterface
 }
 
 export interface GetArticlesResponseInterface {
   articles: GetDetailArticleInterface[]
 }
 
-export const createArticle = async (article: ArticleInterface) => {
+// content : 디테일 / category : string
+export const createArticle = async (article: ArticleDetailInterface) => {
   const res = await fetch(API_ARTICLE_URL_FOR_CSR, {
     method: 'POST',
     headers: {
@@ -72,6 +73,7 @@ export const createArticle = async (article: ArticleInterface) => {
   return res
 }
 
+// content : 디테일 / category : 디테일
 export const getArticleById = async (id: string) => {
   const res = await fetch(`${API_ARTICLE_URL_FOR_SSR}/${id}`, {
     cache: 'no-store',
@@ -80,6 +82,7 @@ export const getArticleById = async (id: string) => {
   return res
 }
 
+// content : 심플 / category : 심플
 export const getArticles = async (searchTerm?: string) => {
   const res = await fetch(
     `${API_ARTICLE_URL_FOR_SSR}${
@@ -93,6 +96,7 @@ export const getArticles = async (searchTerm?: string) => {
   return res
 }
 
+// content : 디테일 / category : string
 export const putArticleById = async (
   id: string,
   revisedArticle: RevisedArticleInterface,
@@ -108,6 +112,7 @@ export const putArticleById = async (
   return res
 }
 
+// content : 심플 / category : 심플
 export const deleteArticleById = async (id: string) => {
   const res = await fetch(`${API_ARTICLE_URL_FOR_CSR}?id=${id}`, {
     method: 'DELETE',

--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -3,7 +3,7 @@ import { ArticleInterface } from './articles'
 
 const API_CATEGORY_URL = `${API_URL_FOR_CSR}/api/categories`
 
-interface CategoryInterface {
+export interface CategoryInterface {
   _id: string
   categoryName: string
   articles: ArticleInterface[]

--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -1,12 +1,12 @@
 import { API_URL_FOR_CSR } from '@/constants/common'
-import { GetSimpleArticleInterface } from './articles'
+import type { GetSimpleArticleInterface } from '@/apis/articles'
 
 const API_CATEGORY_URL = `${API_URL_FOR_CSR}/api/categories`
 
 export interface CategoryInterface {
   _id: string
   categoryName: string
-  articles: GetSimpleArticleInterface[]
+  articles: GetSimpleArticleInterface | string[]
 }
 
 export const createCategory = async (

--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -1,4 +1,4 @@
-import { API_URL_FOR_CSR } from '../constants/common'
+import { API_URL_FOR_CSR } from '@/constants/common'
 import { GetSimpleArticleInterface } from './articles'
 
 const API_CATEGORY_URL = `${API_URL_FOR_CSR}/api/categories`

--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -1,12 +1,12 @@
 import { API_URL_FOR_CSR } from '../constants/common'
-import { ArticleInterface } from './articles'
+import { GetSimpleArticleInterface } from './articles'
 
 const API_CATEGORY_URL = `${API_URL_FOR_CSR}/api/categories`
 
 export interface CategoryInterface {
   _id: string
   categoryName: string
-  articles: ArticleInterface[]
+  articles: GetSimpleArticleInterface[]
 }
 
 export const createCategory = async (

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import Category from '@/models/category'
 import { Article, ArticleContent } from '@/models/article'
 import { connectMongoDB } from '@/libs/mongodb'
-import { RevisedArticleInterface } from '@/apis/articles'
+import { ArticleDetailInterface } from '@/apis/articles'
 
 export const PUT = async (
   request: NextRequest,
@@ -14,10 +14,10 @@ export const PUT = async (
   },
 ) => {
   const {
-    newTitle: title,
-    newContent: { text, html },
-    newCategory: category,
-  }: RevisedArticleInterface = await request.json()
+    title,
+    content: { text, html },
+    category,
+  }: ArticleDetailInterface = await request.json()
 
   await connectMongoDB()
 

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { connectMongoDB } from '@/libs/mongodb'
-import { ArticleInterface } from '@/apis/articles'
+import { ArticleDetailInterface } from '@/apis/articles'
 import { Article, ArticleContent } from '@/models/article'
 import Category from '@/models/category'
 
@@ -10,7 +10,7 @@ export const POST = async (request: NextRequest) => {
     title,
     content: { text, html },
     category,
-  }: ArticleInterface = await request.json()
+  }: ArticleDetailInterface = await request.json()
   await connectMongoDB()
 
   const { _id: articleContentId } = await ArticleContent.create({

--- a/src/components/ArticleForm/_shared/types.ts
+++ b/src/components/ArticleForm/_shared/types.ts
@@ -1,15 +1,15 @@
-import { ArticleInterface } from '@/apis/articles'
+import { ArticleDetailInterface } from '@/apis/articles'
 
 export type ArticleTitleContentType = Pick<
-  ArticleInterface,
+  ArticleDetailInterface,
   'title' | 'content'
 >
 
-export interface ArticleFormProps extends ArticleInterface {
-  onSubmit: (article: ArticleInterface) => Promise<void>
+export interface ArticleFormProps extends ArticleDetailInterface {
+  onSubmit: (article: ArticleDetailInterface) => Promise<void>
 }
 
-export type NewTitleType = ArticleInterface['title']
-export type NewContentType = ArticleInterface['content']
+export type NewTitleType = ArticleDetailInterface['title']
+export type NewContentType = ArticleDetailInterface['content']
 
 export type HandleChangeNewContentType = Pick<NewContentType, 'html' | 'text'>

--- a/src/components/ArticleForm/_shared/types.ts
+++ b/src/components/ArticleForm/_shared/types.ts
@@ -1,10 +1,5 @@
 import { ArticleDetailInterface } from '@/apis/articles'
 
-export type ArticleTitleContentType = Pick<
-  ArticleDetailInterface,
-  'title' | 'content'
->
-
 export interface ArticleFormProps extends ArticleDetailInterface {
   onSubmit: (article: ArticleDetailInterface) => Promise<void>
 }

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -27,7 +27,7 @@ const ArticleForm = ({ title, content, onSubmit }: ArticleFormProps) => {
     onSubmit({
       title: newTitle,
       content: newContent,
-      category: '',
+      category: null,
     })
   }
 

--- a/src/containers/Article/Edit/index.tsx
+++ b/src/containers/Article/Edit/index.tsx
@@ -21,19 +21,8 @@ const ArticleEdit = ({
   const router = useRouter()
 
   const handleSubmit = async (editedArticle: ArticleDetailInterface) => {
-    const { title, content, category } = editedArticle
-
-    if (!title || !content) {
-      alert('Title and description are required')
-      return
-    }
-
     try {
-      const res = await putArticleById(id, {
-        title,
-        content,
-        category,
-      })
+      const res = await putArticleById(id, editedArticle)
 
       if (!res.ok) {
         throw new Error(`HTTP error! Status: ${res.status}`)

--- a/src/containers/Article/Edit/index.tsx
+++ b/src/containers/Article/Edit/index.tsx
@@ -3,15 +3,15 @@
 import { useRouter } from 'next/navigation'
 
 import {
-  ArticleInterface,
-  GetArticleInterface,
+  ArticleDetailInterface,
+  GetDetailArticleInterface,
   putArticleById,
 } from '@/apis/articles'
 
 import ArticleForm from '@/components/ArticleForm'
 
 interface Props {
-  article: GetArticleInterface
+  article: GetDetailArticleInterface
 }
 
 // TODO: 카테고리 수정
@@ -20,23 +20,19 @@ const ArticleEdit = ({
 }: Props) => {
   const router = useRouter()
 
-  const handleSubmit = async (editedArticle: ArticleInterface) => {
-    const {
-      title: newTitle,
-      content: newContent,
-      category: newCategory,
-    } = editedArticle
+  const handleSubmit = async (editedArticle: ArticleDetailInterface) => {
+    const { title, content, category } = editedArticle
 
-    if (!newTitle || !newContent) {
+    if (!title || !content) {
       alert('Title and description are required')
       return
     }
 
     try {
       const res = await putArticleById(id, {
-        newTitle,
-        newContent,
-        newCategory,
+        title,
+        content,
+        category,
       })
 
       if (!res.ok) {

--- a/src/containers/Article/Read/index.tsx
+++ b/src/containers/Article/Read/index.tsx
@@ -1,13 +1,13 @@
 import dayjs from 'dayjs'
 
-import { GetArticleInterface } from '@/apis/articles'
+import { GetDetailArticleInterface } from '@/apis/articles'
 
 import EditButtons from './EditButtons'
 import ArticleContent from '@/components/ArticleContent'
 import Comments from './Comments'
 
 interface Props {
-  article: GetArticleInterface
+  article: GetDetailArticleInterface
 }
 
 const Article = ({

--- a/src/containers/Article/Write/index.tsx
+++ b/src/containers/Article/Write/index.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 
 // TODO: 카테고리 수정
-import { ArticleInterface, createArticle } from '@/apis/articles'
+import { ArticleDetailInterface, createArticle } from '@/apis/articles'
 
 const DynamicArticleForm = dynamic(
   () => {
@@ -16,7 +16,7 @@ const DynamicArticleForm = dynamic(
 const ArticleWrite = () => {
   const router = useRouter()
 
-  const handleSubmit = async (article: ArticleInterface) => {
+  const handleSubmit = async (article: ArticleDetailInterface) => {
     const { title, content } = article
 
     if (!title || !content) {
@@ -41,7 +41,7 @@ const ArticleWrite = () => {
     <DynamicArticleForm
       title={''}
       content={{ text: '', html: '' }}
-      category={''}
+      category={null}
       onSubmit={handleSubmit}
     />
   )

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 
-import { ArticleOfGetArticlesResponseInterface } from '@/apis/articles'
+import { GetArticlesResponseInterface } from '@/apis/articles'
 
 import Search from './Search'
 
 interface Props {
-  articles: ArticleOfGetArticlesResponseInterface[] | undefined
+  articles: GetArticlesResponseInterface['articles'] | undefined
 }
 
 const Home = ({ articles }: Props) => {


### PR DESCRIPTION
# What is this PR?

Article에 소속된 `Interfaces` 들 정리

# Changes

- `ArticleInterface`를 `ArticleSimpleInterface` & `ArticleDetailInterface`로 분리 및 적용
    - 분리 이유
        1. `ArticleInterface` 가 어떨 때는 simple한 value가, 어떨 때는 detail한 value가 필요한데 그것들을 하나의 interface로 사용하니 불편함.
        2. 또한, `ArticleInterface` 를 사용하는 곳에서 사용성이 딱 이 2가지로(simple & detail)로 분류 됨.
            
            (세부적으로는 아닐 수도 있으나 이상 없을 것으로 판단)
            
    - `ArticleSimpleInterface`
        - `content`, `category` 속성에 string만 들어감
    - `ArticleDetailInterface`
        - `content`, `category` 속성에 디테일한 하위 interface가 들어감
- `RevisedArticleInterface` 삭제
    - 이유 : 굳이 필요 없어서

# Questions

- 알맞게 잘 한 걸까?

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다.

<details>
        <summary>구글링이 짱인 것 같다.</summary>

interface를 import하다가 순환참조 에러 (에러 문 : `Error: Dependency cycle detected. import/no-cycle`)이 발생했고 어떻게 해결해야 할지 한참 고민했었다. (아주 오랜 시간은 아니였지만..)

chatGPT에서는 의존성을 최소화 하라는데.. 그걸 나도 하고 싶은데 구체적인 답안이 나오지 않아서 답답했었고 ‘순환 참조’ 등을 검색하다가 에러문을 직접 구글링 해보니 누군가 비슷한 에러를 겪은 것을 github issue에 올렸고 거기서 이모지(👍)가 가장 많은 것을 찾아보니 `import type` 을 사용하면 해결된다고 적어둔 것을 발견했다.

단순히 `type` 하나 추가한다고 될 까 했는데 해결이 되었다.

비교적 간단했고 역시 구글링에서 나처럼 삽질을 해본 사람들의 해결방안을 확인하는 것이 베스트라는 것을 느꼈다.
</details>
