### PR TITLE
feat/delete-category-function : category 삭제 기능

### DIFF
--- a/src/containers/Category/Each/EditButtons/index.tsx
+++ b/src/containers/Category/Each/EditButtons/index.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { deleteCategoryById } from '@/apis/categories'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  categoryId: string
+}
+
+const EditButtons = ({ categoryId }: Props) => {
+  const router = useRouter()
+
+  const handleClickDeleteCategoryButton = async () => {
+    const confirmed = window.confirm(
+      '정말 삭제하시겠습니까? 아티클들은 삭제되지 않습니다.',
+    )
+
+    if (!confirmed) return
+
+    try {
+      const res = await deleteCategoryById(categoryId)
+
+      if (!res.ok) {
+        router.push('/')
+        throw new Error('카테고리를 삭제하는데 실패했습니다.')
+      }
+
+      router.push('/')
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return <button onClick={handleClickDeleteCategoryButton}>삭제</button>
+}
+
+export default EditButtons

--- a/src/containers/Category/Each/EditButtons/index.tsx
+++ b/src/containers/Category/Each/EditButtons/index.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { deleteCategoryById } from '@/apis/categories'
 import { useRouter } from 'next/navigation'
+
+import { deleteCategoryById } from '@/apis/categories'
 
 interface Props {
   categoryId: string

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -2,15 +2,18 @@ import Link from 'next/link'
 import dayjs from 'dayjs'
 
 import { GetCategoryByIdInterface } from '@/apis/categories'
+import EditButtons from './EditButtons'
 
 interface Props {
   category: GetCategoryByIdInterface
 }
 
-const EachCategory = ({ category: { categoryName, articles } }: Props) => {
+const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
   return (
     <section>
       <h1>{categoryName}</h1>
+      <EditButtons categoryId={_id} />
+
       {articles.length ? (
         <div>
           {articles.map(({ _id, title, createdAt }, idx) => (

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import dayjs from 'dayjs'
 
 import { GetCategoryByIdInterface } from '@/apis/categories'
+
 import EditButtons from './EditButtons'
 
 interface Props {
@@ -16,8 +17,8 @@ const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
 
       {articles.length ? (
         <div>
-          {articles.map(({ _id, title, createdAt }, idx) => (
-            <Link key={_id} href={`/article/${_id}`}>
+          {articles.map(({ _id: articleId, title, createdAt }, idx) => (
+            <Link key={articleId} href={`/article/${_id}`}>
               <h2>{`${idx + 1}. ${title}`}</h2>
               <div>{dayjs(createdAt).format('YYYY-MM-DD')}</div>
             </Link>


### PR DESCRIPTION
# What is this PR?

category 삭제 기능 넣기

# Changes

- 각 카테고리 페이지에 ‘삭제’버튼이 추가되었고 이를 통해 삭제 가능

# Screenshot

| action | image                      |
| ------ | -------------------------- |
| 1. 개별 카테고리 페이지 진입     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/44f94418-0aaa-4aac-8afb-bd1eb6b71ebe' height='200'/> |
| 2. 삭제 버튼 클릭 후, confirm 창의 ‘확인’버튼을 누른다.     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/54a0899b-1bf0-4df0-b4fa-dad4571e9735' height='200'/> |
| 3. 삭제 후, home 페이지로 돌아간 다음 category 탭을 클릭하여 삭제 된 것 확인     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/7ad2b7ed-92b6-4406-81a2-37a6352f7488' height='200'/> |

# Questions

더 잘 짤 수 있는 방법이 있을까?

# Test Checklist

Screenshot의 흐름 참고하기
