### PR TITLE
feat/update-category-function : category 업데이트 기능

### DIFF
--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   categoryId: string
 }
 
-const EditButtons = ({ categoryId }: Props) => {
+const EachCategoryHeader = ({ categoryId }: Props) => {
   const router = useRouter()
 
   const handleClickDeleteCategoryButton = async () => {
@@ -32,7 +32,12 @@ const EditButtons = ({ categoryId }: Props) => {
     }
   }
 
-  return <button onClick={handleClickDeleteCategoryButton}>삭제</button>
+  return (
+    <div>
+      <button>수정</button>
+      <button onClick={handleClickDeleteCategoryButton}>삭제</button>
+    </div>
+  )
 }
 
-export default EditButtons
+export default EachCategoryHeader

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -16,9 +16,11 @@ const EachCategoryHeader = ({ categoryName, categoryId }: Props) => {
   const [isCategoryNameEditable, setIsCategoryNameEditable] =
     useState<boolean>(false)
 
-  const handleClickEditButton = () => {}
+  const handleClickEditButton = () => {
+    setIsCategoryNameEditable(true)
+  }
 
-  const handleClickDeleteCategoryButton = async () => {
+  const handleClickDeleteButton = async () => {
     const confirmed = window.confirm(
       '정말 삭제하시겠습니까? 아티클들은 삭제되지 않습니다.',
     )
@@ -43,7 +45,7 @@ const EachCategoryHeader = ({ categoryName, categoryId }: Props) => {
     <div>
       <h1 contentEditable={isCategoryNameEditable}>{categoryName}</h1>
       <button onClick={handleClickEditButton}>수정</button>
-      <button onClick={handleClickDeleteCategoryButton}>삭제</button>
+      <button onClick={handleClickDeleteButton}>삭제</button>
     </div>
   )
 }

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { FormEvent } from 'react'
+import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { deleteCategoryById, putCategoryById } from '@/apis/categories'
-import { useState } from 'react'
 import useIsLogin from '@/hooks/useIsLogin'
 
 interface Props {
@@ -54,7 +53,7 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
   }
 
   const handleClickApplyButton = async () => {
-    if (!categoryName) return confirm('카테고리 이름을 입력해주세요.')
+    if (!categoryName) return window.confirm('카테고리 이름을 입력해주세요.')
 
     try {
       const res = await putCategoryById({ _id: categoryId, categoryName })

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -4,7 +4,7 @@ import { FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { deleteCategoryById } from '@/apis/categories'
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 interface Props {
   initCategoryName: string
@@ -64,7 +64,9 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
         {categoryName}
       </h1>
       {isCategoryNameEditable ? (
-        <button onClick={handleClickApplyButton}>적용</button>
+        <button onClick={handleClickApplyButton} disabled={!categoryName}>
+          적용
+        </button>
       ) : (
         <>
           <button onClick={handleClickEditButton}>수정</button>

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -3,7 +3,7 @@
 import { FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 
-import { deleteCategoryById } from '@/apis/categories'
+import { deleteCategoryById, putCategoryById } from '@/apis/categories'
 import { useState } from 'react'
 
 interface Props {
@@ -20,10 +20,10 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
     initCategoryName,
   )
 
-  const handleInputCategoryName = ({
-    currentTarget: { textContent },
+  const handleChangeCategoryName = ({
+    currentTarget: { innerText },
   }: FormEvent<HTMLHeadingElement>) => {
-    setCategoryName(textContent)
+    setCategoryName(innerText)
   }
 
   const handleClickEditButton = () => {
@@ -51,13 +51,26 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
     }
   }
 
-  const handleClickApplyButton = () => {}
+  const handleClickApplyButton = async () => {
+    if (!categoryName) return confirm('카테고리 이름을 입력해주세요.')
+
+    try {
+      const res = await putCategoryById({ _id: categoryId, categoryName })
+
+      if (!res.ok) {
+        router.push('/')
+        throw new Error('카테고리를 수정하는데 실패했습니다.')
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
   return (
     <div>
       <h1
         contentEditable={isCategoryNameEditable}
-        onInput={handleInputCategoryName}
+        onChange={handleChangeCategoryName}
         suppressContentEditableWarning
         placeholder="카테고리 이름을 1자 이상 적어주세요."
       >

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -1,20 +1,30 @@
 'use client'
 
+import { FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { deleteCategoryById } from '@/apis/categories'
-import { useState } from 'react'
+import React, { useState } from 'react'
 
 interface Props {
-  categoryName: string
+  initCategoryName: string
   categoryId: string
 }
 
-const EachCategoryHeader = ({ categoryName, categoryId }: Props) => {
+const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
   const router = useRouter()
 
   const [isCategoryNameEditable, setIsCategoryNameEditable] =
     useState<boolean>(false)
+  const [categoryName, setCategoryName] = useState<string | null>(
+    initCategoryName,
+  )
+
+  const handleInputCategoryName = ({
+    currentTarget: { textContent },
+  }: FormEvent<HTMLHeadingElement>) => {
+    setCategoryName(textContent)
+  }
 
   const handleClickEditButton = () => {
     setIsCategoryNameEditable(true)
@@ -41,11 +51,26 @@ const EachCategoryHeader = ({ categoryName, categoryId }: Props) => {
     }
   }
 
+  const handleClickApplyButton = () => {}
+
   return (
     <div>
-      <h1 contentEditable={isCategoryNameEditable}>{categoryName}</h1>
-      <button onClick={handleClickEditButton}>수정</button>
-      <button onClick={handleClickDeleteButton}>삭제</button>
+      <h1
+        contentEditable={isCategoryNameEditable}
+        onInput={handleInputCategoryName}
+        suppressContentEditableWarning
+        placeholder="카테고리 이름을 1자 이상 적어주세요."
+      >
+        {categoryName}
+      </h1>
+      {isCategoryNameEditable ? (
+        <button onClick={handleClickApplyButton}>적용</button>
+      ) : (
+        <>
+          <button onClick={handleClickEditButton}>수정</button>
+          <button onClick={handleClickDeleteButton}>삭제</button>
+        </>
+      )}
     </div>
   )
 }

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -3,13 +3,20 @@
 import { useRouter } from 'next/navigation'
 
 import { deleteCategoryById } from '@/apis/categories'
+import { useState } from 'react'
 
 interface Props {
+  categoryName: string
   categoryId: string
 }
 
-const EachCategoryHeader = ({ categoryId }: Props) => {
+const EachCategoryHeader = ({ categoryName, categoryId }: Props) => {
   const router = useRouter()
+
+  const [isCategoryNameEditable, setIsCategoryNameEditable] =
+    useState<boolean>(false)
+
+  const handleClickEditButton = () => {}
 
   const handleClickDeleteCategoryButton = async () => {
     const confirmed = window.confirm(
@@ -34,7 +41,8 @@ const EachCategoryHeader = ({ categoryId }: Props) => {
 
   return (
     <div>
-      <button>수정</button>
+      <h1 contentEditable={isCategoryNameEditable}>{categoryName}</h1>
+      <button onClick={handleClickEditButton}>수정</button>
       <button onClick={handleClickDeleteCategoryButton}>삭제</button>
     </div>
   )

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 
 import { deleteCategoryById, putCategoryById } from '@/apis/categories'
 import { useState } from 'react'
+import useIsLogin from '@/hooks/useIsLogin'
 
 interface Props {
   initCategoryName: string
@@ -13,6 +14,7 @@ interface Props {
 
 const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
   const router = useRouter()
+  const { isLoggedin } = useIsLogin()
 
   const [isCategoryNameEditable, setIsCategoryNameEditable] =
     useState<boolean>(false)
@@ -76,14 +78,18 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
       >
         {initCategoryName}
       </h1>
-      {isCategoryNameEditable ? (
-        <button onClick={handleClickApplyButton} disabled={!categoryName}>
-          적용
-        </button>
-      ) : (
+      {isLoggedin && (
         <>
-          <button onClick={handleClickEditButton}>수정</button>
-          <button onClick={handleClickDeleteButton}>삭제</button>
+          {isCategoryNameEditable ? (
+            <button onClick={handleClickApplyButton} disabled={!categoryName}>
+              적용
+            </button>
+          ) : (
+            <>
+              <button onClick={handleClickEditButton}>수정</button>
+              <button onClick={handleClickDeleteButton}>삭제</button>
+            </>
+          )}
         </>
       )}
     </div>

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -20,10 +20,10 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
     initCategoryName,
   )
 
-  const handleChangeCategoryName = ({
-    currentTarget: { innerText },
+  const handleInputCategoryName = ({
+    currentTarget: { textContent },
   }: FormEvent<HTMLHeadingElement>) => {
-    setCategoryName(innerText)
+    setCategoryName(textContent)
   }
 
   const handleClickEditButton = () => {
@@ -70,11 +70,11 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
     <div>
       <h1
         contentEditable={isCategoryNameEditable}
-        onChange={handleChangeCategoryName}
+        onInput={handleInputCategoryName}
         suppressContentEditableWarning
         placeholder="카테고리 이름을 1자 이상 적어주세요."
       >
-        {categoryName}
+        {initCategoryName}
       </h1>
       {isCategoryNameEditable ? (
         <button onClick={handleClickApplyButton} disabled={!categoryName}>

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -73,7 +73,6 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
         contentEditable={isCategoryNameEditable}
         onInput={handleInputCategoryName}
         suppressContentEditableWarning
-        placeholder="카테고리 이름을 1자 이상 적어주세요."
       >
         {initCategoryName}
       </h1>

--- a/src/containers/Category/Each/Header/index.tsx
+++ b/src/containers/Category/Each/Header/index.tsx
@@ -62,6 +62,8 @@ const EachCategoryHeader = ({ initCategoryName, categoryId }: Props) => {
         router.push('/')
         throw new Error('카테고리를 수정하는데 실패했습니다.')
       }
+
+      setIsCategoryNameEditable(false)
     } catch (error) {
       console.log(error)
     }

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -12,8 +12,7 @@ interface Props {
 const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
   return (
     <section>
-      <h1>{categoryName}</h1>
-      <EachCategoryHeader categoryId={_id} />
+      <EachCategoryHeader categoryName={categoryName} categoryId={_id} />
 
       {articles.length ? (
         <div>

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
   return (
     <section>
-      <EachCategoryHeader categoryName={categoryName} categoryId={_id} />
+      <EachCategoryHeader initCategoryName={categoryName} categoryId={_id} />
 
       {articles.length ? (
         <div>

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 
 import { GetCategoryByIdInterface } from '@/apis/categories'
 
-import EditButtons from './EditButtons'
+import EachCategoryHeader from './Header'
 
 interface Props {
   category: GetCategoryByIdInterface
@@ -13,7 +13,7 @@ const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
   return (
     <section>
       <h1>{categoryName}</h1>
-      <EditButtons categoryId={_id} />
+      <EachCategoryHeader categoryId={_id} />
 
       {articles.length ? (
         <div>

--- a/src/containers/Category/Each/index.tsx
+++ b/src/containers/Category/Each/index.tsx
@@ -17,7 +17,7 @@ const EachCategory = ({ category: { _id, categoryName, articles } }: Props) => {
       {articles.length ? (
         <div>
           {articles.map(({ _id: articleId, title, createdAt }, idx) => (
-            <Link key={articleId} href={`/article/${_id}`}>
+            <Link key={articleId} href={`/article/${articleId}`}>
               <h2>{`${idx + 1}. ${title}`}</h2>
               <div>{dayjs(createdAt).format('YYYY-MM-DD')}</div>
             </Link>


### PR DESCRIPTION
# What is this PR?

category 업데이트 기능

# Changes

- 폴더 네이밍 수정
    - `Category/Each/EditButtons` → `Category/Each/Header`
        
        이유 : 편집 버튼 뿐만 아니라 제목 등 다양한 요소들이 들어가게 되었기 때문
        
- 수정 기능 추가
    - `수정`, `적용` 버튼 추가
        - `수정` 버튼 클릭 시
            
            ‘적용’ 버튼이 뜨고 ‘카테고리 이름’이 수정 가능한 상태로 변경됨.
            
        - `적용` 버튼 클릭 시
            
            수정한 ‘카테고리 이름’으로 업데이트 됨.
- 로그인 되어 있지 않을 경우
    
    카테고리의 이름 `수정`, `삭제` 표출 안됨
            

# Screenshot

| action | image                      |
| ------ | -------------------------- |
| 1. 개별 카테고리를 하여 수정, 삭제 버튼을 확인     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/f24dacf2-60b9-4e3b-abef-ce11f5a1ccef' height='200'/> |
| 2. 수정 버튼을 누르고 카테고리 이름 수정     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/a9de1125-4a82-405e-82c7-94bbe6feee24' height='200'/> |
| 3. 카테고리 이름에 아무 글자도 없을 경우, 적용 버튼 비활성화 | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/8e4bef2d-7899-4c94-90f7-9394c9256de5' height='200'/> |
| 4. 적용 버튼을 클릭하여 수정된 카테고리 이름 확인     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/38dbd6d1-4df9-404c-8c43-bfc7a76c1a02' height='200'/> |
| 5. 로그아웃 된 경우, 수정 및 삭제 버튼이 보이지 않음 | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/3eb8e44c-a63b-4f83-932c-bafc4e3198de' height='200'/> |

# Notes

- 카테고리 이름에 `contentEditable` 속성 + `onInput` 을 활용함
    - 이유 : 바로 수정 가능한 상태로 변경시키기 위해

# Questions

더 잘 짤 수 있는 방법이 궁금함.

# Test Checklist

screenshot의 flow 참고

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다. 읽지 않으셔도 괜찮습니다.

<details>
        <summary>onInput에서 값 구하기</summary>

onInput은 onChange와 다르게 e.target.value로 값을 얻을 수 없었다. ts에서 에러가 나기 때문이다.

그래서 일단 ts에러가 나지 않는 currentTarget까지 입력한 다음.. 구글링도 해보고 chatGPT에게도 물어봐도 답이 제대로 나오지 않던 차에 직접 property를 쭉 보다가 textContent를 발견했다.

결국 제대로된 방법을 찾아낸 것인데 이런 식으로도 문제를 해결할 수 있다는 것을 배웠다.
</details>
<details>
        <summary>참고하던 벨로그에서 알게된 contentEditable 속성</summary>

어떻게 카테고리 이름을 바로 변경할 수 있을지 찾아보던 차에 개발자 도구로 벨로그를 보니 contentEditable의 값이 계속 변경되는 것을 알 수 있었다.

벨로퍼트 님이 만드신 사이트 이기 때문에 더 신뢰도가 높았고 그래서 나 또한 도입하게 되었다.

그래서 onInput도 처음으로 알게 되었다.

새로 알게된 2가지의 속성 모두 흥미로웠다. 특히 h1태그에서 바로 편집 가능한 버전으로 바뀌는 contentEditable 속성은 혁신이었다.

굿 👍
</details>
